### PR TITLE
Potential fix for code scanning alert no. 72: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-azure-prod.yml
+++ b/.github/workflows/deploy-azure-prod.yml
@@ -3,6 +3,10 @@
 
 name: Azure Deploy prod
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/keystoneconcertband/development/security/code-scanning/72](https://github.com/keystoneconcertband/development/security/code-scanning/72)

Add explicit `permissions` at the workflow root so both `build` and `deploy` jobs inherit least-privilege defaults.  
Best minimal safe fix here is:

- `contents: read` (needed by `actions/checkout`)
- `actions: read` (safe for interacting with workflow artifacts/actions metadata)

No write scopes are required by the shown steps. This preserves existing behavior while constraining token access.

**File to change:** `.github/workflows/deploy-azure-prod.yml`  
**Region:** after `name:` and before `on:` (top-level workflow keys).  
No imports/dependencies/methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
