### PR TITLE
Potential fix for code scanning alert no. 71: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-azure-dev.yml
+++ b/.github/workflows/deploy-azure-dev.yml
@@ -9,6 +9,10 @@ on:
       - dev
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/keystoneconcertband/development/security/code-scanning/71](https://github.com/keystoneconcertband/development/security/code-scanning/71)

Add an explicit `permissions` block at the workflow root so both jobs inherit least-privilege defaults.  
For this workflow, `contents: read` is sufficient for checkout and general read access. Add `actions: read` as a safe explicit allowance for action metadata/artifact-related operations without granting write scopes. No functional behavior should change.

Edit **`.github/workflows/deploy-azure-dev.yml`** by inserting the permissions block between `workflow_dispatch:` and `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
