### PR TITLE
Implement caching

### DIFF
--- a/book.php
+++ b/book.php
@@ -1,3 +1,11 @@
+<?php
+session_start();
+if (empty($_SESSION['book_csrf_token'])) {
+    $_SESSION['book_csrf_token'] = bin2hex(random_bytes(32));
+}
+$bookCsrfToken = $_SESSION['book_csrf_token'];
+$formCreatedAt = time();
+?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -46,6 +54,9 @@
                         <input type="text" class="form-control" id="honeypot" name="honeypot" autocomplete="off"
                             tabindex="-1">
                     </div>
+                    <input type="hidden" id="csrf_token" name="csrf_token" value="<?= htmlentities($bookCsrfToken, ENT_QUOTES, 'UTF-8') ?>">
+                    <input type="hidden" id="formCreatedAt" name="formCreatedAt" value="<?= htmlentities($formCreatedAt, ENT_QUOTES, 'UTF-8') ?>">
+                    <input type="hidden" id="jsCheck" name="jsCheck" value="">
                     <div class="col-lg-12">
                         If you are interested in booking the band, please fill out the form below with your contact
                         information so we can get back to you.<br>

--- a/bookServer.php
+++ b/bookServer.php
@@ -1,6 +1,8 @@
 <?php 
+	session_start();
 	# This is the public page for booking
- 	include_once("includes/class/kcbBase.class.php");
+	include_once("includes/class/kcbBase.class.php");
+	include_once("includes/class/kcbPublic.class.php");
 	$response = "";
 
 	function isValidEmailAddress($email) {
@@ -10,20 +12,25 @@
 
 	// Only allow POST requests
 	if ($_SERVER['REQUEST_METHOD'] === 'POST') {	
-		if(!isset($_REQUEST['txtName'])) {
-			$response = "Name is required.";
-		}
-		else if(isset($_REQUEST['txtPhone']) && $_REQUEST['txtPhone'] !== "" && strlen($_REQUEST['txtPhone']) < 10) {
-			$response = "Phone number must be 10 digits.";
-		}
-		else if(!isset($_REQUEST['txtEmail'])) {
-			$response = "Email is required.";
-		}
-		else if(!isValidEmailAddress($_REQUEST['txtEmail'])) {
-			$response = "Please enter a valid email address.";
-		}
-		else if(!isset($_REQUEST['txtComments'])) {
-			$response = "Comments are required.";
+		$book = new KCBPublic();
+		$response = $book->validateFormSubmission($_REQUEST, 'book_csrf_token');
+
+		if($response === "") {
+			if(!isset($_REQUEST['txtName'])) {
+				$response = "Name is required.";
+			}
+			else if(isset($_REQUEST['txtPhone']) && $_REQUEST['txtPhone'] !== "" && strlen($_REQUEST['txtPhone']) < 10) {
+				$response = "Phone number must be 10 digits.";
+			}
+			else if(!isset($_REQUEST['txtEmail'])) {
+				$response = "Email is required.";
+			}
+			else if(!isValidEmailAddress($_REQUEST['txtEmail'])) {
+				$response = "Please enter a valid email address.";
+			}
+			else if(!isset($_REQUEST['txtComments'])) {
+				$response = "Comments are required.";
+			}
 		}
 		
 		if($response === "") {

--- a/bookServer.php
+++ b/bookServer.php
@@ -1,8 +1,7 @@
 <?php 
 	session_start();
 	# This is the public page for booking
-	include_once("includes/class/kcbBase.class.php");
-	include_once("includes/class/kcbPublic.class.php");
+	require_once 'includes/class/kcbPublic.class.php';
 	$response = "";
 
 	function isValidEmailAddress($email) {

--- a/concerts.php
+++ b/concerts.php
@@ -1,5 +1,5 @@
 <?php 	
-	include_once('includes/class/kcbPublic.class.php');
+	require_once 'includes/class/kcbPublic.class.php';
 	global $cncrts;
 	$cncrts = new KCBPublic();
 ?>

--- a/includes/class/kcbBase.class.php
+++ b/includes/class/kcbBase.class.php
@@ -14,13 +14,13 @@ class KcbBase
 {
     private $log;
 
-    public function __construct()
+    public function __construct($startSession = true)
     {
         // Show errors if dev environment
         $this->defaultSettings($this->isDevEnv());
         $this->log = new Log();
 
-        if (session_status() == PHP_SESSION_NONE) {
+        if ($startSession && session_status() == PHP_SESSION_NONE) {
             session_start();
         }
     }

--- a/includes/class/kcbPublic.class.php
+++ b/includes/class/kcbPublic.class.php
@@ -165,13 +165,40 @@ class KCBPublic
         }
 
         if (!empty($_SERVER['HTTP_REFERER'])) {
-            $refererHost = parse_url($_SERVER['HTTP_REFERER'], PHP_URL_HOST);
-            if ($refererHost && stripos($refererHost, $_SERVER['SERVER_NAME']) === false) {
+            $refererHost = $this->normalizeHost(parse_url($_SERVER['HTTP_REFERER'], PHP_URL_HOST));
+            $requestHost = $this->normalizeHost(isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : $_SERVER['SERVER_NAME']);
+
+            if ($refererHost && $requestHost && !$this->hostsMatch($refererHost, $requestHost)) {
                 return "Invalid form submission source.";
             }
         }
 
         return null;
+    }
+
+    private function normalizeHost($host)
+    {
+        $host = strtolower(trim((string)$host));
+        if ($host === '') {
+            return '';
+        }
+
+        $host = preg_replace('/:\d+$/', '', $host);
+        return $host;
+    }
+
+    private function hostsMatch($refererHost, $requestHost)
+    {
+        if ($refererHost === $requestHost) {
+            return true;
+        }
+
+        // Allow the same site to be served from or redirected through a subdomain
+        // such as dev.example.com vs example.com, or www.example.com vs example.com.
+        return (
+            substr($refererHost, -strlen('.' . $requestHost)) === '.' . $requestHost ||
+            substr($requestHost, -strlen('.' . $refererHost)) === '.' . $refererHost
+        );
     }
 
     private function processEmail($joinArray)

--- a/includes/class/kcbPublic.class.php
+++ b/includes/class/kcbPublic.class.php
@@ -37,11 +37,6 @@ class KCBPublic
         $response = $this->validateJoin($joinArray);
 
         if (empty($response)) {
-            // Require the shared form security protections.
-            $response = $this->validateFormSubmission($joinArray, 'join_csrf_token');
-        }
-
-        if (empty($response)) {
             // Check for spam
             $response = $this->processSpam($joinArray);
 
@@ -102,7 +97,8 @@ class KCBPublic
             return "Invalid form submission.";
         }
 
-        return $this->validateSpamProtection($formArray);
+        $response = $this->validateSpamProtection($formArray);
+        return $response === null ? "" : $response;
     }
 
     /* PRIVATE FUNCTIONS */

--- a/includes/class/kcbPublic.class.php
+++ b/includes/class/kcbPublic.class.php
@@ -37,8 +37,8 @@ class KCBPublic
         $response = $this->validateJoin($joinArray);
 
         if (empty($response)) {
-            // Require JS and timing protections
-            $response = $this->validateSpamProtection($joinArray);
+            // Require the shared form security protections.
+            $response = $this->validateFormSubmission($joinArray, 'join_csrf_token');
         }
 
         if (empty($response)) {
@@ -95,6 +95,16 @@ class KCBPublic
         return $response;
     }
 
+    public function validateFormSubmission($formArray, $csrfSessionKey)
+    {
+        if (empty($formArray['csrf_token']) || empty($_SESSION[$csrfSessionKey]) ||
+            !hash_equals($_SESSION[$csrfSessionKey], $formArray['csrf_token'])) {
+            return "Invalid form submission.";
+        }
+
+        return $this->validateSpamProtection($formArray);
+    }
+
     /* PRIVATE FUNCTIONS */
     private function getDb()
     {
@@ -145,17 +155,21 @@ class KCBPublic
         return $response;
     }
 
-    private function validateSpamProtection($joinArray)
+    private function validateSpamProtection($formArray)
     {
-        if (empty($joinArray['jsCheck']) || $joinArray['jsCheck'] !== 'enabled') {
+        if (!empty($formArray['honeypot'])) {
+            return "Invalid request.";
+        }
+
+        if (empty($formArray['jsCheck']) || $formArray['jsCheck'] !== 'enabled') {
             return "Please enable JavaScript to submit this form.";
         }
 
-        if (empty($joinArray['formCreatedAt']) || !ctype_digit($joinArray['formCreatedAt'])) {
+        if (empty($formArray['formCreatedAt']) || !ctype_digit($formArray['formCreatedAt'])) {
             return "Invalid form submission.";
         }
 
-        $formAge = time() - (int)$joinArray['formCreatedAt'];
+        $formAge = time() - (int)$formArray['formCreatedAt'];
         if ($formAge < 3) {
             return "Please take a moment to complete the form before submitting.";
         }

--- a/includes/class/kcbPublic.class.php
+++ b/includes/class/kcbPublic.class.php
@@ -9,7 +9,8 @@ class KCBPublic
 
     public function __construct()
     {
-        $this->setKcb(new KcbBase());
+        // Anonymous read-only pages should not create a session, allowing HTTP caching.
+        $this->setKcb(new KcbBase(false));
         $this->setDB(new KCBPublicDb());
     }
 

--- a/includes/class/kcbPublic.db.class.php
+++ b/includes/class/kcbPublic.db.class.php
@@ -52,27 +52,68 @@ class KCBPublicDb
     /* Select Queries */
     public function getCurrentConcert()
     {
-        return $this->getDb()->row("SELECT concertBegin, Title, pants, chair, address
-                                    FROM kcb_schedule
-                                    WHERE concertBegin >= CURRENT_TIMESTAMP
-                                    ORDER BY concertBegin");
+        $cacheKey = 'kcb_public_current_concert';
+        $cached = $this->getCached($cacheKey, $cacheHit);
+        if ($cacheHit) {
+            return $cached;
+        }
+
+        $concert = $this->getDb()->row("SELECT concertBegin, Title, pants, chair, address
+                                        FROM kcb_schedule
+                                        WHERE concertBegin >= CURRENT_TIMESTAMP
+                                        ORDER BY concertBegin");
+        $this->setCached($cacheKey, $concert, 60);
+        return $concert;
     }
 
     public function getConcertSchedule()
     {
-        return $this->getDb()->query("SELECT concertBegin, Title, pants, chair, address
-                                      FROM kcb_schedule
-                                      WHERE year(concertBegin) = year(CURRENT_TIMESTAMP)
-                                      ORDER BY concertBegin");
+        $cacheKey = 'kcb_public_concert_schedule';
+        $cached = $this->getCached($cacheKey, $cacheHit);
+        if ($cacheHit) {
+            return $cached;
+        }
+
+        $schedule = $this->getDb()->query("SELECT concertBegin, Title, pants, chair, address
+                                          FROM kcb_schedule
+                                          WHERE year(concertBegin) = year(CURRENT_TIMESTAMP)
+                                          ORDER BY concertBegin");
+        $this->setCached($cacheKey, $schedule, 300);
+        return $schedule;
     }
 
     public function getHomepageMessages()
     {
-        return $this->getDb()->query("SELECT title, message, message_type
-                                      FROM kcb_homepage_messages
-                                      WHERE start_dt <= CURRENT_TIMESTAMP
-                                        AND end_dt >= CURRENT_TIMESTAMP
-                                      ORDER BY start_dt");
+        $cacheKey = 'kcb_public_homepage_messages';
+        $cached = $this->getCached($cacheKey, $cacheHit);
+        if ($cacheHit) {
+            return $cached;
+        }
+
+        $messages = $this->getDb()->query("SELECT title, message, message_type
+                                          FROM kcb_homepage_messages
+                                          WHERE start_dt <= CURRENT_TIMESTAMP
+                                            AND end_dt >= CURRENT_TIMESTAMP
+                                          ORDER BY start_dt");
+        $this->setCached($cacheKey, $messages, 300);
+        return $messages;
+    }
+
+    private function getCached($key, &$cacheHit)
+    {
+        $cacheHit = false;
+        if (!function_exists('apcu_fetch') || !apcu_enabled()) {
+            return null;
+        }
+
+        return apcu_fetch($key, $cacheHit);
+    }
+
+    private function setCached($key, $value, $ttl)
+    {
+        if (function_exists('apcu_store') && apcu_enabled()) {
+            apcu_store($key, $value, $ttl);
+        }
     }
 
     public function checkDupPendingUser($email)

--- a/includes/class/kcbPublic.db.class.php
+++ b/includes/class/kcbPublic.db.class.php
@@ -3,6 +3,10 @@ require_once "db.class.php";
 
 class KCBPublicDb
 {
+    private const CURRENT_CONCERT_CACHE_KEY = 'kcb_public_current_concert';
+    private const CONCERT_SCHEDULE_CACHE_KEY = 'kcb_public_concert_schedule';
+    private const HOMEPAGE_MESSAGES_CACHE_KEY = 'kcb_public_homepage_messages';
+
     private $db;
 
     public function __construct()
@@ -52,7 +56,7 @@ class KCBPublicDb
     /* Select Queries */
     public function getCurrentConcert()
     {
-        $cacheKey = 'kcb_public_current_concert';
+        $cacheKey = self::CURRENT_CONCERT_CACHE_KEY;
         $cached = $this->getCached($cacheKey, $cacheHit);
         if ($cacheHit) {
             return $cached;
@@ -68,7 +72,7 @@ class KCBPublicDb
 
     public function getConcertSchedule()
     {
-        $cacheKey = 'kcb_public_concert_schedule';
+        $cacheKey = self::CONCERT_SCHEDULE_CACHE_KEY;
         $cached = $this->getCached($cacheKey, $cacheHit);
         if ($cacheHit) {
             return $cached;
@@ -78,13 +82,13 @@ class KCBPublicDb
                                           FROM kcb_schedule
                                           WHERE year(concertBegin) = year(CURRENT_TIMESTAMP)
                                           ORDER BY concertBegin");
-        $this->setCached($cacheKey, $schedule, 300);
+        $this->setCached($cacheKey, $schedule, 3600);
         return $schedule;
     }
 
     public function getHomepageMessages()
     {
-        $cacheKey = 'kcb_public_homepage_messages';
+        $cacheKey = self::HOMEPAGE_MESSAGES_CACHE_KEY;
         $cached = $this->getCached($cacheKey, $cacheHit);
         if ($cacheHit) {
             return $cached;
@@ -97,6 +101,17 @@ class KCBPublicDb
                                           ORDER BY start_dt");
         $this->setCached($cacheKey, $messages, 300);
         return $messages;
+    }
+
+    public static function clearScheduleCache()
+    {
+        self::clearCached(self::CURRENT_CONCERT_CACHE_KEY);
+        self::clearCached(self::CONCERT_SCHEDULE_CACHE_KEY);
+    }
+
+    public static function clearHomepageMessagesCache()
+    {
+        self::clearCached(self::HOMEPAGE_MESSAGES_CACHE_KEY);
     }
 
     private function getCached($key, &$cacheHit)
@@ -113,6 +128,13 @@ class KCBPublicDb
     {
         if (function_exists('apcu_store') && apcu_enabled()) {
             apcu_store($key, $value, $ttl);
+        }
+    }
+
+    private static function clearCached($key)
+    {
+        if (function_exists('apcu_delete') && apcu_enabled()) {
+            apcu_delete($key);
         }
     }
 

--- a/includes/class/member.class.php
+++ b/includes/class/member.class.php
@@ -11,9 +11,9 @@ class Member
     private $kcb;
 
     /* PUBLIC FUNCTIONS */
-    public function __construct($authReq)
+    public function __construct($authReq, $startSession = true)
     {
-        $this->setKcb(new KcbBase());
+        $this->setKcb(new KcbBase($startSession));
         $this->setDB(new MemberDB());
 
         if ($authReq) {

--- a/includes/class/member.db.class.php
+++ b/includes/class/member.db.class.php
@@ -32,14 +32,49 @@ class MemberDB
     // Gets the members by instrument
     public function getMembers($instrument)
     {
+        $cacheKey = 'kcb_public_members_' . rawurlencode($instrument);
+        $cached = self::getPublicCache($cacheKey, $cacheHit);
+        if ($cacheHit) {
+            return $cached;
+        }
+
         $this->getDb()->bind("instrument", $instrument);
-        return $this->getDb()->query("SELECT firstName, lastName, displayFullName
-                                      FROM kcb_members m
-                                      JOIN kcb_instrument i ON m.UID = i.member_uid
-                                      WHERE i.instrument = :instrument
-                                        AND disabled = 0
-                                        AND accountType <> 3
-                                      ORDER BY lastName, firstName");
+        $members = $this->getDb()->query("SELECT firstName, lastName, displayFullName
+                                          FROM kcb_members m
+                                          JOIN kcb_instrument i ON m.UID = i.member_uid
+                                          WHERE i.instrument = :instrument
+                                            AND disabled = 0
+                                            AND accountType <> 3
+                                          ORDER BY lastName, firstName");
+        self::setPublicCache($cacheKey, $members, 3600);
+        return $members;
+    }
+
+    public static function clearPublicMembersCache()
+    {
+        foreach (array('baritone', 'bassClarinet', 'bassoon', 'clarinet', 'flute', 'frenchHorn', 'oboe', 'percussion', 'saxophone', 'trombone', 'trumpet', 'tuba') as $instrument) {
+            $key = 'kcb_public_members_' . rawurlencode($instrument);
+            if (function_exists('apcu_delete') && apcu_enabled()) {
+                apcu_delete($key);
+            }
+        }
+    }
+
+    private static function getPublicCache($key, &$cacheHit)
+    {
+        $cacheHit = false;
+        if (!function_exists('apcu_fetch') || !apcu_enabled()) {
+            return null;
+        }
+
+        return apcu_fetch($key, $cacheHit);
+    }
+
+    private static function setPublicCache($key, $value, $ttl)
+    {
+        if (function_exists('apcu_store') && apcu_enabled()) {
+            apcu_store($key, $value, $ttl);
+        }
     }
 
     // Gets the member information by email address

--- a/includes/class/protectedAdmin.class.php
+++ b/includes/class/protectedAdmin.class.php
@@ -174,6 +174,7 @@ class ProtectedAdmin
                     if ($this->updateEmails($uid, $email, true)) {
                         if ($this->updateInstruments($uid, $instrument)) {
                             $this->getDb()->executeTransaction();
+                            MemberDB::clearPublicMembersCache();
                         } else {
                             $this->getDb()->rollBackTransaction();
                             $retValue = "update_instrument_error";
@@ -207,8 +208,9 @@ class ProtectedAdmin
 				$this->getDb()->beginTransaction();
 
 				if($this->getDb()->delAllEmails($uid)) {
-					if($this->getDb()->deleteMember($uid, $updateUser)) {
+                    if($this->getDb()->deleteMember($uid, $updateUser)) {
                         $this->getDb()->executeTransaction();
+                        MemberDB::clearPublicMembersCache();
                         $retValue = "success";
 					}
 					else {

--- a/includes/class/protectedAdmin.class.php
+++ b/includes/class/protectedAdmin.class.php
@@ -3,6 +3,7 @@
 // member is its parent
 require_once "member.class.php";
 require_once "member.db.class.php";
+require_once "kcbPublic.db.class.php";
 
 class ProtectedAdmin
 {
@@ -50,6 +51,7 @@ class ProtectedAdmin
         }
 
         if ($this->getDb()->addHomepageMessage($title, $message, $message_type, $start_dt, $end_dt, $_SESSION["email"])) {
+            KCBPublicDb::clearHomepageMessagesCache();
             return "success";
         }
     }
@@ -61,6 +63,7 @@ class ProtectedAdmin
         }
 
         if ($this->getDb()->editHomepageMessage($uid, $title, $message, $message_type, $start_dt, $end_dt, $_SESSION["email"])) {
+            KCBPublicDb::clearHomepageMessagesCache();
             return "success";
         }
     }
@@ -117,6 +120,7 @@ class ProtectedAdmin
         }
 
         if ($this->getDb()->addSchedule($title, $concertBegin, $pants, $chair, $address, $_SESSION['email'] ?? '')) {
+            KCBPublicDb::clearScheduleCache();
             return "success";
         }
     }
@@ -128,6 +132,7 @@ class ProtectedAdmin
         }
 
         if ($this->getDb()->editSchedule($uid, $title, $concertBegin, $pants, $chair, $address, $_SESSION['email'] ?? '')) {
+            KCBPublicDb::clearScheduleCache();
             return "success";
         }
     }

--- a/includes/class/protectedAdmin.class.php
+++ b/includes/class/protectedAdmin.class.php
@@ -2,7 +2,6 @@
 // This class is for methods which must be protected, so use must have a valid session to run these queries
 // member is its parent
 require_once "member.class.php";
-require_once "member.db.class.php";
 require_once "kcbPublic.db.class.php";
 
 class ProtectedAdmin

--- a/includes/class/protectedMember.class.php
+++ b/includes/class/protectedMember.class.php
@@ -109,7 +109,8 @@ class ProtectedMember {
 					if($this->upsertAddress($uid, $mbrArray, $updateUser)) {
 						if($this->updateEmails($uid, $email, true, false)) {
 							if($this->updateInstruments($uid, $instrument)) {
-								$this->getDb()->executeTransaction();							
+								$this->getDb()->executeTransaction();
+								MemberDB::clearPublicMembersCache();
 							}
 							else {
 								$this->getDb()->rollBackTransaction();
@@ -167,7 +168,8 @@ class ProtectedMember {
 					if($this->upsertAddress($uid, $mbrArray, $updateUser)) {
 						if($this->updateEmails($uid, $email, true, false)) {
 							if($this->updateInstruments($uid, $instrument)) {
-								$this->getDb()->executeTransaction();							
+								$this->getDb()->executeTransaction();
+								MemberDB::clearPublicMembersCache();
 							}
 							else {
 								$this->getDb()->rollBackTransaction();
@@ -212,7 +214,8 @@ class ProtectedMember {
 				
 				if($this->getDb()->removeMember($uid, $updateUser)) {
 					if($this->updateEmails($uid, array(), $deleteEmailAddress, false)) {
-						$this->getDb()->executeTransaction();							
+						$this->getDb()->executeTransaction();
+						MemberDB::clearPublicMembersCache();
 					}
 					else {
 						$this->getDb()->rollBackTransaction();

--- a/includes/class/protectedMember.class.php
+++ b/includes/class/protectedMember.class.php
@@ -2,7 +2,6 @@
 // This class is for methods which must be protected, so use must have a valid session to run these queries
 // member is its parent
 require_once "member.class.php";
-require_once "member.db.class.php";
 	
 class ProtectedMember {
 	private $db;

--- a/includes/common_meta.php
+++ b/includes/common_meta.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/public_cache.php'; ?>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/includes/public_cache.php
+++ b/includes/public_cache.php
@@ -10,5 +10,5 @@ if (session_status() === PHP_SESSION_ACTIVE) {
     return;
 }
 
-header('Cache-Control: public, max-age=300, stale-while-revalidate=3600');
+header('Cache-Control: public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400');
 header('Vary: Cookie');

--- a/includes/public_cache.php
+++ b/includes/public_cache.php
@@ -1,0 +1,14 @@
+<?php
+
+// Public pages can be cached only when the request is not tied to a session.
+if (session_status() === PHP_SESSION_NONE && isset($_COOKIE[session_name()])) {
+    session_start();
+}
+
+if (session_status() === PHP_SESSION_ACTIVE) {
+    header('Cache-Control: private, no-store, no-cache, must-revalidate');
+    return;
+}
+
+header('Cache-Control: public, max-age=300, stale-while-revalidate=3600');
+header('Vary: Cookie');

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php
-	include_once('includes/class/kcbPublic.class.php');
+	require_once 'includes/class/kcbPublic.class.php';
 	global $homepage;
 	$homepage = new KCBPublic();
 ?>

--- a/joinServer.php
+++ b/joinServer.php
@@ -11,17 +11,12 @@ function isValidEmailAddress($email) {
 
 // Only allow POST requests
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (empty($_POST['csrf_token']) || empty($_SESSION['join_csrf_token']) ||
-        !hash_equals($_SESSION['join_csrf_token'], $_POST['csrf_token'])) {
-        $response = "Invalid form submission.";
+    $email = isset($_REQUEST['txtEmail']) ? $_REQUEST['txtEmail'] : '';
+    if ($email !== '' && !isValidEmailAddress($email)) {
+        $response = "Please enter a valid email address.";
     } else {
-        $email = isset($_REQUEST['txtEmail']) ? $_REQUEST['txtEmail'] : '';
-        if ($email !== '' && !isValidEmailAddress($email)) {
-            $response = "Please enter a valid email address.";
-        } else {
-            $join = new KCBPublic();
-            $response = $join->joinSubmit($_REQUEST);
-        }
+        $join = new KCBPublic();
+        $response = $join->joinSubmit($_REQUEST);
     }
 } else {
     $response = "invalid_request";

--- a/joinServer.php
+++ b/joinServer.php
@@ -11,12 +11,16 @@ function isValidEmailAddress($email) {
 
 // Only allow POST requests
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $email = isset($_REQUEST['txtEmail']) ? $_REQUEST['txtEmail'] : '';
-    if ($email !== '' && !isValidEmailAddress($email)) {
-        $response = "Please enter a valid email address.";
-    } else {
-        $join = new KCBPublic();
-        $response = $join->joinSubmit($_REQUEST);
+    $join = new KCBPublic();
+    $response = $join->validateFormSubmission($_REQUEST, 'join_csrf_token');
+
+    if ($response === "") {
+        $email = isset($_REQUEST['txtEmail']) ? $_REQUEST['txtEmail'] : '';
+        if ($email !== '' && !isValidEmailAddress($email)) {
+            $response = "Please enter a valid email address.";
+        } else {
+            $response = $join->joinSubmit($_REQUEST);
+        }
     }
 } else {
     $response = "invalid_request";

--- a/joinServer.php
+++ b/joinServer.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 # This is the public page for booking
-include_once("includes/class/kcbPublic.class.php");
+require_once 'includes/class/kcbPublic.class.php';
 $response = "";
 
 function isValidEmailAddress($email) {

--- a/kcb-js/book.js
+++ b/kcb-js/book.js
@@ -2,6 +2,11 @@ document.addEventListener('DOMContentLoaded', function () {
   const form = document.getElementById('frmBook');
   if (!form) return;
 
+  const jsCheck = document.getElementById('jsCheck');
+  if (jsCheck) {
+    jsCheck.value = 'enabled';
+  }
+
   form.addEventListener('submit', function (event) {
     if (event.defaultPrevented || !form.checkValidity()) {
       event.preventDefault();

--- a/members.php
+++ b/members.php
@@ -1,5 +1,5 @@
 <?php
-	include_once('includes/class/member.class.php');
+	require_once 'includes/class/member.class.php';
 	require_once 'includes/asset.php';
 	$mbr = new Member(false, false);
 ?>

--- a/members.php
+++ b/members.php
@@ -1,7 +1,7 @@
 <?php
 	include_once('includes/class/member.class.php');
 	require_once 'includes/asset.php';
-	$mbr = new Member(false);
+	$mbr = new Member(false, false);
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/members/attestation.php
+++ b/members/attestation.php
@@ -1,6 +1,5 @@
 <?php
-include_once("../includes/class/protectedMember.class.php");
-include_once("../includes/class/member.db.class.php");
+require_once '../includes/class/protectedMember.class.php';
 
 if(strtolower(getenv('SEND_ATTESTATION_EMAILS')) !== 'true') {
     http_response_code(403);

--- a/members/currentMembers.php
+++ b/members/currentMembers.php
@@ -1,5 +1,5 @@
 <?php
-include_once '../includes/class/protectedMember.class.php';
+require_once '../includes/class/protectedMember.class.php';
 require_once '../includes/asset.php';
 new ProtectedMember();
 ?>

--- a/members/documents.php
+++ b/members/documents.php
@@ -1,5 +1,5 @@
 <?php
-include_once '../includes/class/protectedMember.class.php';
+require_once '../includes/class/protectedMember.class.php';
 new ProtectedMember();
 ?>
 

--- a/members/documentsServer.php
+++ b/members/documentsServer.php
@@ -1,5 +1,5 @@
 <?php
 	error_reporting(E_ALL | E_STRICT);
-	require('uploadHandler.php');
+	require_once 'uploadHandler.php';
 	$upload_handler = new UploadHandler();
 ?>

--- a/members/homepageMessage.php
+++ b/members/homepageMessage.php
@@ -1,5 +1,5 @@
 <?php
-include_once '../includes/class/protectedMusic.class.php';
+require_once '../includes/class/protectedMusic.class.php';
 require_once '../includes/asset.php';
 new ProtectedMusic();
 ?>

--- a/members/homepageMessageServer.php
+++ b/members/homepageMessageServer.php
@@ -1,6 +1,6 @@
 <?php 
 	# This is the public page for music which the ajax requests call.
-	include_once('../includes/class/protectedAdmin.class.php');
+	require_once '../includes/class/protectedAdmin.class.php';
 	header('Content-Type: application/json');
 
 	$admin = new ProtectedAdmin();

--- a/members/inactiveMembers.php
+++ b/members/inactiveMembers.php
@@ -1,5 +1,5 @@
 <?php
-include_once '../includes/class/protectedMember.class.php';
+require_once '../includes/class/protectedMember.class.php';
 require_once '../includes/asset.php';
 new ProtectedMember();
 ?>

--- a/members/inactiveMembersServer.php
+++ b/members/inactiveMembersServer.php
@@ -1,6 +1,6 @@
 <?php 
 	# This is the public page for member which the ajax requests call.
-	include_once('../includes/class/protectedMember.class.php');
+	require_once '../includes/class/protectedMember.class.php';
 	header('Content-Type: application/json');
 
 	$mbr = new ProtectedMember();

--- a/members/index.php
+++ b/members/index.php
@@ -1,5 +1,5 @@
 <?php
-include_once '../includes/class/member.class.php';
+require_once '../includes/class/member.class.php';
 new Member(true);
 ?>
 

--- a/members/loginStats.php
+++ b/members/loginStats.php
@@ -1,5 +1,5 @@
 <?php
-include_once '../includes/class/protectedAdmin.class.php';
+require_once '../includes/class/protectedAdmin.class.php';
 require_once '../includes/asset.php';
 new protectedAdmin();
 ?>

--- a/members/loginStatsServer.php
+++ b/members/loginStatsServer.php
@@ -1,6 +1,6 @@
 <?php 
 	# This is the public page for music which the ajax requests call.
-	include_once('../includes/class/protectedAdmin.class.php');
+	require_once '../includes/class/protectedAdmin.class.php';
 	header('Content-Type: application/json');
 
 	$stats = new protectedAdmin();

--- a/members/membersPrint.php
+++ b/members/membersPrint.php
@@ -1,6 +1,5 @@
 <?php
-include_once("../includes/class/protectedMember.class.php");
-include_once("../includes/class/member.db.class.php");
+require_once '../includes/class/protectedMember.class.php';
 
 $pMbr = new ProtectedMember();
 $members = $pMbr->getActiveMembers();

--- a/members/membersServer.php
+++ b/members/membersServer.php
@@ -1,6 +1,6 @@
 <?php 
 	# This is the public page for member which the ajax requests call.
-	include_once('../includes/class/protectedMember.class.php');
+	require_once '../includes/class/protectedMember.class.php';
 	header('Content-Type: application/json');
 
 	function isValidEmailAddress($email) {

--- a/members/messageMembers.php
+++ b/members/messageMembers.php
@@ -1,5 +1,5 @@
 <?php
-include_once '../includes/class/protectedAdmin.class.php';
+require_once '../includes/class/protectedAdmin.class.php';
 new protectedAdmin();
 ?>
 

--- a/members/music.php
+++ b/members/music.php
@@ -1,5 +1,5 @@
 <?php
-include_once '../includes/class/protectedMusic.class.php';
+require_once '../includes/class/protectedMusic.class.php';
 require_once '../includes/asset.php';
 new ProtectedMusic();
 ?>

--- a/members/musicServer.php
+++ b/members/musicServer.php
@@ -1,6 +1,6 @@
 <?php 
 	# This is the public page for music which the ajax requests call.
-	include_once('../includes/class/protectedMusic.class.php');
+	require_once '../includes/class/protectedMusic.class.php';
 	header('Content-Type: application/json');
 
 	$music = new ProtectedMusic();

--- a/members/musicTitleSearch.php
+++ b/members/musicTitleSearch.php
@@ -1,6 +1,6 @@
 <?php 
 	# This is the public page for music which the ajax requests call.
-	include_once('../includes/class/protectedMusic.class.php');
+	require_once '../includes/class/protectedMusic.class.php';
 	header('Content-Type: application/json');
 
 	if(isset($_GET['term']) && $_GET['term'] !== "") {

--- a/members/myInfo.php
+++ b/members/myInfo.php
@@ -1,5 +1,5 @@
 <?php
-include_once '../includes/class/protectedMember.class.php';
+require_once '../includes/class/protectedMember.class.php';
 require_once '../includes/asset.php';
 new ProtectedMember();
 ?>

--- a/members/myInfoServer.php
+++ b/members/myInfoServer.php
@@ -45,7 +45,7 @@
 		}
 		
 		if($validRequest) {
-			include_once('../includes/class/protectedMember.class.php');
+			require_once '../includes/class/protectedMember.class.php';
 			$myInfo = new ProtectedMember();
 			
 			$response = $myInfo->updateMember($_SESSION["uid"], $_POST);

--- a/members/pendingMembers.php
+++ b/members/pendingMembers.php
@@ -1,5 +1,5 @@
 <?php
-include_once '../includes/class/protectedAdmin.class.php';
+require_once '../includes/class/protectedAdmin.class.php';
 require_once '../includes/asset.php';
 new ProtectedAdmin();
 ?>

--- a/members/pendingMembersServer.php
+++ b/members/pendingMembersServer.php
@@ -1,6 +1,6 @@
 <?php 
 	# This is the public page for member which the ajax requests call.
-	include_once('../includes/class/protectedAdmin.class.php');
+	require_once '../includes/class/protectedAdmin.class.php';
 	header('Content-Type: application/json');
 
 	$mbr = new ProtectedAdmin();

--- a/members/schedule.php
+++ b/members/schedule.php
@@ -1,5 +1,5 @@
 <?php
-include_once '../includes/class/protectedAdmin.class.php';
+require_once '../includes/class/protectedAdmin.class.php';
 require_once '../includes/asset.php';
 new ProtectedAdmin();
 ?>

--- a/members/scheduleServer.php
+++ b/members/scheduleServer.php
@@ -1,5 +1,5 @@
 <?php
-    include_once('../includes/class/protectedAdmin.class.php');
+    require_once '../includes/class/protectedAdmin.class.php';
     header('Content-Type: application/json');
 
     $admin = new ProtectedAdmin();

--- a/members/uploadHandler.php
+++ b/members/uploadHandler.php
@@ -10,7 +10,7 @@
  * https://opensource.org/licenses/MIT
  */
  
-include_once('../includes/class/kcbBase.class.php');
+require_once '../includes/class/kcbBase.class.php';
 
 class UploadHandler
 {

--- a/membersServer.php
+++ b/membersServer.php
@@ -1,6 +1,6 @@
 <?php 
 	# This is the public page for memberLogin which the ajax requests call.
-	include_once('includes/class/member.class.php');
+	require_once 'includes/class/member.class.php';
 
 	$email = isset($_REQUEST["email"]) ? $_REQUEST["email"] : null;
 	$auth_cd = isset($_REQUEST["auth_cd"]) ? $_REQUEST["auth_cd"] : null;


### PR DESCRIPTION
## Summary
- Added one-hour HTTP caching for anonymous public pages.
- Added APCu caching for public concert, homepage message, schedule, and member roster queries.
- Added targeted cache invalidation after successful admin/member updates.
- Preserved private, uncached behavior for session-based member pages and join forms.
- Prevented anonymous public pages from creating unnecessary sessions.
- Fixes invalid form-source errors on the dev site and adds shared submission hardening for both public forms.

## Cache Durations
- Public HTML: 1 hour
- Concert schedule: 1 hour
- Member roster queries: 1 hour
- Homepage messages: 5 minutes
- Current concert: 60 seconds

## Join and Book Updates
- Normalize referer and request hosts, including ports and subdomains.
- Add shared CSRF validation for join and booking forms.
- Add JavaScript, timing, expiration, and honeypot checks to booking submissions.
- Route both endpoints through the shared public form validator.
- Preserve existing join-field and booking-email validation.

## Cleaned up the remaining dependency loads across 32 files.
- Replaced mandatory include_once calls with require_once.
- Removed unnecessary parentheses.
- Removed redundant member.db.class.php includes.
- Converted the document handler to require_once.